### PR TITLE
alterações para que consiga navegar entre links

### DIFF
--- a/orfalius.js
+++ b/orfalius.js
@@ -425,6 +425,9 @@ function processParagraph(document, element, dirname, prefix) {
             removable.push(...processChildren(document, element, dirname, prefix));
         }
     }
+    if (innerHTML.includes('.md')) {
+        element.innerHTML = innerHTML.replace(/\.md\b/g, '.html');
+    }
 
     return removable;
 }

--- a/src/exemplo.md
+++ b/src/exemplo.md
@@ -1,8 +1,6 @@
-Título
-======
+# Título
 
-Subtítulo
----------
+## Subtítulo
 
 Para criar um parágrafo, basta escrever um texto contínuo, sem pular linhas.
 
@@ -14,13 +12,17 @@ Você também pode criar
 
 assim como
 
-* listas;
+- listas;
 
-* não-ordenadas
+- não-ordenadas
 
-e imagens. Lembre que todas as imagens devem estar em uma subpasta *img*.
+e imagens. Lembre que todas as imagens devem estar em uma subpasta _img_.
 
 ![](logo.png)
+
+Consegue mudar de pagina colocando:
+
+[outra pagina](exemplo2.md)
 
 Para tabelas, usa-se a [notação do
 MultiMarkdown](https://fletcher.github.io/MultiMarkdown-6/syntax/tables.html),
@@ -28,28 +30,28 @@ que é muito flexível. Vale a pena abrir esse link para saber todas as
 possibilidades.
 
 | coluna a | coluna b |
-|----------|----------|
+| -------- | -------- |
 | 1        | 2        |
 
-Ao longo de um texto, você pode usar *itálico*, **negrito**, {red}(vermelho) e
+Ao longo de um texto, você pode usar _itálico_, **negrito**, {red}(vermelho) e
 [[tecla]]. Também pode usar uma equação LaTeX: $f(n) \leq g(n)$. Se for muito
 grande, você pode isolá-la em um parágrafo.
 
 $$\lim_{n \rightarrow \infty} \frac{f(n)}{g(n)} \leq 1$$
 
 Para inserir uma animação, use `md :` seguido do nome de uma pasta onde as
-imagens estão. Essa pasta também deve estar em *img*.
+imagens estão. Essa pasta também deve estar em _img_.
 
 :bubble
 
 Você também pode inserir código, inclusive especificando a linguagem.
 
-``` py
+```py
 def f():
     print('hello world')
 ```
 
-``` c
+```c
 void f() {
     printf("hello world\n");
 }
@@ -61,11 +63,9 @@ Se não especificar nenhuma, o código fica com colorização de terminal.
 hello world
 ```
 
-
 !!! Aviso
 Este é um exemplo de aviso, entre `md !!!`.
 !!!
-
 
 ??? Exercício
 

--- a/src/exemplo2.md
+++ b/src/exemplo2.md
@@ -1,0 +1,3 @@
+# outra pagina
+
+[primeira pagina](exemplo.md)


### PR DESCRIPTION
Adiciona suporte para navegação em links Markdown convertidos para HTML. Agora, ao criar um link Markdown no HTML gerado, é possível navegar diretamente para o destino correspondente no próprio HTML.